### PR TITLE
Template method: small typo fix

### DIFF
--- a/behavioral/template-method/README.md
+++ b/behavioral/template-method/README.md
@@ -19,12 +19,12 @@ TemplateMethod says: I am doing the bulk of the work
 ConcreteStruct1 says: Implemented Operation1
 TemplateMethod says: But I let subclasses override some operations
 ConcreteStruct1 says: Implemented Operation2
-TemplateMethod says: But I am doing the bulk of the work anyway   
+TemplateMethod says: But I am doing the bulk of the work anyway
 
 Same client code can work with different concrete implementations:
 TemplateMethod says: I am doing the bulk of the work
 ConcreteStruct2 says: Implemented Operation1
 TemplateMethod says: But I let subclasses override some operations
 ConcreteStruct2 says: Implemented Operation2
-TemplateMethod says: But I am doing the bulk of the work anyway   
+TemplateMethod says: But I am doing the bulk of the work anyway
 ```

--- a/behavioral/template-method/README.md
+++ b/behavioral/template-method/README.md
@@ -19,12 +19,12 @@ TemplateMethod says: I am doing the bulk of the work
 ConcreteStruct1 says: Implemented Operation1
 TemplateMethod says: But I let subclasses override some operations
 ConcreteStruct1 says: Implemented Operation2
-TemplateMethod says: But I am doing the bulk of the work anyway
+TemplateMethod says: But I am doing the bulk of the work anyway   
 
 Same client code can work with different concrete implementations:
 TemplateMethod says: I am doing the bulk of the work
-ConcreteStruct1 says: Implemented Operation1
+ConcreteStruct2 says: Implemented Operation1
 TemplateMethod says: But I let subclasses override some operations
-ConcreteStruct1 says: Implemented Operation2
-TemplateMethod says: But I am doing the bulk of the work anyway
+ConcreteStruct2 says: Implemented Operation2
+TemplateMethod says: But I am doing the bulk of the work anyway   
 ```

--- a/behavioral/template-method/main.rs
+++ b/behavioral/template-method/main.rs
@@ -62,5 +62,5 @@ fn main() {
     println!();
 
     println!("Same client code can work with different concrete implementations:");
-    client_code(ConcreteStruct1);
+    client_code(ConcreteStruct2);
 }


### PR DESCRIPTION
Thanks for great repo!

I've noticed a small mistake in template-method example.

On the other hand, maybe we can provide a more distinguishable example for this pattern like in https://refactoring.guru/design-patterns/template-method/go/example