### PR TITLE
fix typo - AdvancedRemove -> AdvancedRemote

### DIFF
--- a/behavioral/chain-of-responsibility/department.rs
+++ b/behavioral/chain-of-responsibility/department.rs
@@ -28,7 +28,7 @@ pub trait Department {
 }
 
 /// Helps to wrap an object into a boxed type.
-pub(self) fn into_next(
+pub fn into_next(
     department: impl Department + Sized + 'static,
 ) -> Option<Box<dyn Department>> {
     Some(Box::new(department))

--- a/behavioral/chain-of-responsibility/department.rs
+++ b/behavioral/chain-of-responsibility/department.rs
@@ -28,8 +28,6 @@ pub trait Department {
 }
 
 /// Helps to wrap an object into a boxed type.
-pub fn into_next(
-    department: impl Department + Sized + 'static,
-) -> Option<Box<dyn Department>> {
+pub fn into_next(department: impl Department + Sized + 'static) -> Option<Box<dyn Department>> {
     Some(Box::new(department))
 }

--- a/behavioral/command/main.rs
+++ b/behavioral/command/main.rs
@@ -23,7 +23,7 @@ fn main() {
     app.add_layer(
         Dialog::around(EditView::default().with_name("Editor"))
             .title("Type and use buttons")
-            .button("Copy", |s| execute(s, CopyCommand::default()))
+            .button("Copy", |s| execute(s, CopyCommand))
             .button("Cut", |s| execute(s, CutCommand::default()))
             .button("Paste", |s| execute(s, PasteCommand::default()))
             .button("Undo", undo)

--- a/structural/bridge/main.rs
+++ b/structural/bridge/main.rs
@@ -2,7 +2,7 @@ mod device;
 mod remotes;
 
 use device::{Device, Radio, Tv};
-use remotes::{AdvancedRemove, BasicRemote, HasMutableDevice, Remote};
+use remotes::{AdvancedRemote, BasicRemote, HasMutableDevice, Remote};
 
 fn main() {
     test_device(Tv::default());
@@ -16,7 +16,7 @@ fn test_device(device: impl Device + Clone) {
     basic_remote.device().print_status();
 
     println!("Tests with advanced remote.");
-    let mut advanced_remote = AdvancedRemove::new(device);
+    let mut advanced_remote = AdvancedRemote::new(device);
     advanced_remote.power();
     advanced_remote.mute();
     advanced_remote.device().print_status();

--- a/structural/bridge/remotes/advanced.rs
+++ b/structural/bridge/remotes/advanced.rs
@@ -2,11 +2,11 @@ use crate::device::Device;
 
 use super::{HasMutableDevice, Remote};
 
-pub struct AdvancedRemove<D: Device> {
+pub struct AdvancedRemote<D: Device> {
     device: D,
 }
 
-impl<D: Device> AdvancedRemove<D> {
+impl<D: Device> AdvancedRemote<D> {
     pub fn new(device: D) -> Self {
         Self { device }
     }
@@ -17,10 +17,10 @@ impl<D: Device> AdvancedRemove<D> {
     }
 }
 
-impl<D: Device> HasMutableDevice<D> for AdvancedRemove<D> {
+impl<D: Device> HasMutableDevice<D> for AdvancedRemote<D> {
     fn device(&mut self) -> &mut D {
         &mut self.device
     }
 }
 
-impl<D: Device> Remote<D> for AdvancedRemove<D> {}
+impl<D: Device> Remote<D> for AdvancedRemote<D> {}

--- a/structural/bridge/remotes/mod.rs
+++ b/structural/bridge/remotes/mod.rs
@@ -1,7 +1,7 @@
 mod advanced;
 mod basic;
 
-pub use advanced::AdvancedRemove;
+pub use advanced::AdvancedRemote;
 pub use basic::BasicRemote;
 
 use crate::device::Device;


### PR DESCRIPTION
There are a few places where "AdvancedRemote" was misspelled as "AdvancedRemove"

https://refactoring.guru/design-patterns/bridge/rust/example